### PR TITLE
Allow overriding settings from Chromium's common.gypi

### DIFF
--- a/gyp_packager.py
+++ b/gyp_packager.py
@@ -60,6 +60,9 @@ if __name__ == '__main__':
   # Always include common.gypi.
   args.extend(['-I' + os.path.join(src_dir, 'build', 'common.gypi')])
 
+  # Allow overriding settings from Chromium's common.gypi
+  args.extend(['-I' + os.path.join(src_dir, 'common_overrides.gypi')])
+
   # Set these default GYP_DEFINES if user does not set the value explicitly.
   _DEFAULT_DEFINES = {'test_isolation_mode': 'noop',
                       'use_glib': 0,

--- a/packager/common_overrides.gypi
+++ b/packager/common_overrides.gypi
@@ -1,0 +1,19 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+#
+# This file contains global overrides to the chromium common.gypi settings .
+
+{
+  'target_defaults': {
+    'conditions': [
+      ['OS=="mac"', {
+        'xcode_settings' : {
+          'CLANG_CXX_LIBRARY': 'libc++', # -stdlib=libc++
+        },
+      }],
+    ],
+  },
+}


### PR DESCRIPTION
Build settings are coming from the Chromium build settings in packager/build/common.gypi.
We need to override those settings and set CLANG_CXX_LIBRARY = libc++ for MacOSX builds.
packager/common.gypi does some override but only for packages that explicitly include it.
We want a global override.
Introduce packager/common_overrides.gypi which is injected as an argument to gyp in gyp_packager.py